### PR TITLE
Removed unnecessary camera permission check

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -270,7 +270,9 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         setConfiguration(options);
         resultCollector = new ResultCollector(promise, multiple);
 
-        permissionsCheck(activity, promise, Arrays.asList(Manifest.permission.CAMERA, Manifest.permission.WRITE_EXTERNAL_STORAGE), new Callable<Void>() {
+        permissionsCheck(activity, promise,
+                Collections.singletonList(Manifest.permission.WRITE_EXTERNAL_STORAGE),
+                new Callable<Void>() {
             @Override
             public Void call() throws Exception {
                 initiateCamera(activity);


### PR DESCRIPTION
It was checking for camera permissions, which isn't necessary because the library will forward to the phone's Camera App to actually use the camera. 